### PR TITLE
Fix undefined config errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,23 +48,23 @@ export class JsonBox {
         return Array.isArray(data) ? data.map(record => record[JsonBox.RECORD_ID_KEY]) : data[JsonBox.RECORD_ID_KEY];
     }
 
-    public async read(boxId: string, collection?: string, config?: JsonBoxConfig) {
+    public async read(boxId: string, collection?: string, config: JsonBoxConfig = {}) {
         const response = await axios.get(this.getUrl(boxId, collection, config));
         return response.status === 200 ? response.data : false;
     }
 
     public async create(data: any, boxId: string, collection?: string) {
-        const response = await axios.post(this.getUrl(boxId, collection), data);
+        const response = await axios.post(this.getUrl(boxId, collection, {}), data);
         return response.status === 200 ? response.data : false;
     }
 
     public async update(data: any, boxId: string, recordId: string) {
-        const response = await axios.put(this.getUrl(boxId, recordId), data);
+        const response = await axios.put(this.getUrl(boxId, recordId, {}), data);
         return response.status === 200 ? response.data : false;
     }
 
     public async delete(boxId: string, recordId: string) {
-        const response = await axios.delete(this.getUrl(boxId, recordId));
+        const response = await axios.delete(this.getUrl(boxId, recordId, {}));
         return response.status === 200 ? response.data : false;
     }
 


### PR DESCRIPTION
The current master branch throws an error when using any of the API functions:
`(node:3724) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'sort' of undefined`
This is because it is trying to retrieve `sort`, `skip`, `limit`, and `query` from a JSON object that does not exist. This pull request fixes that.